### PR TITLE
Custom domains require a CNAME file containing just the custom domain…

### DIFF
--- a/website/siteConfig.js
+++ b/website/siteConfig.js
@@ -51,6 +51,9 @@ const siteConfig = {
   onPageNav: 'separate',
   // No .html extensions for paths.
   cleanUrl: true,
+  //  https://docusaurus.io/docs/en/site-config
+  //  The CNAME for your website. It will go into a CNAME file when your site is built.
+  cname: 'getpanoptes.io',
 
   // Open Graph and Twitter card images.
   ogImage: 'img/ogImage.png',


### PR DESCRIPTION
… in the 'built' pages branch.  This is what the settings page does.  'cname' in siteConfig.js should create that file during a publish event.  Without it, the travis builds remove the CNAME file, and they have to be recreated.

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
